### PR TITLE
Add css-only tooltip to show image description

### DIFF
--- a/ImagePickerList.css
+++ b/ImagePickerList.css
@@ -1,33 +1,33 @@
 .flex-container {
     display: flex;
     flex-wrap: wrap;
-    background-color:white;
+    background-color: white;
 }
 
 .flex-container>div {
     background-color: #1c2836;
     margin: 10px 10px 10px 0px;
-    padding:10px;
+    padding: 10px;
     font-size: 30px;
-    width:150px;
-    height:150px;
+    width: 150px;
+    height: 150px;
     vertical-align: middle;
-    border-radius: 5px;    
-}    
+    border-radius: 5px;
+}
 
 .sys {
-    font-style: italic;   
+    font-style: italic;
     background-color: #476689;
     background-color: #6c8dae;
-    color:white;
+    color: white;
 }
 
 .sys a {
-    color:white;
+    color: white;
 }
 
-img { 
-    padding: 8px;    
+img {
+    padding: 8px;
     display: block;
     position: relative;
     top: 50%;
@@ -39,8 +39,82 @@ img {
     margin-right: auto;
 }
 
-h3, h4, h5 {
-    margin: 15px 0 3px 0; 
+/**
+ * Tooltip Styles
+ */
+
+/* Add this attribute to the element that needs a tooltip */
+
+[data-tooltip] {
+    position: relative;
+    z-index: 2;
+    cursor: pointer;
+}
+
+/* Hide the tooltip content by default */
+
+[data-tooltip]:before,
+[data-tooltip]:after {
+    visibility: hidden;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=0);
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Position tooltip above the element */
+
+[data-tooltip]:before {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-bottom: 5px;
+    margin-left: -80px;
+    padding: 7px;
+    width: 260px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    background-color: #000;
+    background-color: hsla(0, 0%, 20%, 0.9);
+    color: #fff;
+    content: attr(data-tooltip);
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.2;
+}
+
+/* Triangle hack to make tooltip look like a speech bubble */
+
+[data-tooltip]:after {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    width: 0;
+    border-top: 5px solid #000;
+    border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    content: " ";
+    font-size: 0;
+    line-height: 0;
+}
+
+/* Show tooltip content on hover */
+
+[data-tooltip]:hover:before,
+[data-tooltip]:hover:after {
+    visibility: visible;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+    filter: progid: DXImageTransform.Microsoft.Alpha(Opacity=100);
+    opacity: 1;
+}
+
+h3,
+h4,
+h5 {
+    margin: 15px 0 3px 0;
     background-color: #dee5ee;
     font-weight: bold;
     padding: 5px 5px 5px 8px;

--- a/ImagePickerList.module
+++ b/ImagePickerList.module
@@ -74,10 +74,11 @@ class ImagePickerList extends Process implements Module {
                     foreach ($p->$f as $i) {
                         if ($i->width > 260) {
                             $origurl = $i->url;
+                            $desc = ($i->description ? ' data-tooltip="' . $i->description . '"' : '');
                             $i = $i->width(260);
                         } else
                             $origurl = $i->url;
-                        $out .= '<div class="imgcont"><img title="' . $i . '" class="selectableimg lazyload" data-origurl=' . $origurl . ' data-src="' . $i->url . '"></div>';
+                        $out .= '<div class="imgcont"' . $desc . '><img title="' . $i . '" class="selectableimg lazyload" data-origurl=' . $origurl . ' data-src="' . $i->url . '"></div>';
                     }
                     $out .= '</div>';
                 }


### PR DESCRIPTION
First of, I love this module. I wished this module is part of the core of PW.

Some of the sites that I managed/built have a lot of images with descriptions so I thought it would be nice to be able to see those descriptions when picking an image. See screenshot below:

<img width="654" alt="screen shot 2018-11-03 at 9 35 49 am" src="https://user-images.githubusercontent.com/1151181/47952305-ef971f80-df4b-11e8-9d1c-ed053fc5c782.png">


